### PR TITLE
Allow bootstrapping and running on non-Debian systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,7 +178,10 @@ cython_debug/
 
 \#*
 
+.python-version
 .bootstrap
+.setup-arch
+.setup-debian
 foo.txt
 *~
 /tools/geckodriver-v0.35.0-linux64.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -58,12 +58,13 @@ setup-debian: .setup-debian
 .setup-debian:
 	sudo apt install -y libmysqlclient-dev build-essential python3.12-dev
 	pyenv install -s 3.12
-	$(call run_in_all_subdirs,setup-debian)
+	$(call run_in_all_subdirs,bootstrap)
 	touch .setup-debian
 
 setup-arch: .setup-arch
 
 .setup-arch:
+	$(call run_in_all_subdirs,bootstrap)
 	touch .setup-arch
 
 #-#

--- a/Makefile
+++ b/Makefile
@@ -49,15 +49,22 @@ help:
 #-#   bootstraps the environment
 bootstrap: .bootstrap
 
-.bootstrap: tests/data/sanitized-test-db.sql
-	# To non-Debian Linux user - You may have to do something about this.
-	# libmysqlclient-dev (or equivalent) is required to build the mysql clint
-	# and other mysql client is known to not work with arxiv-base.
-	sudo apt install -y libmysqlclient-dev build-essential python3.12-dev
-	#
-	pyenv install -s 3.12
+.bootstrap: tests/data/sanitized-test-db.sql setup-$(OS)
 	$(call run_in_all_subdirs,bootstrap)
 	touch .bootstrap
+
+setup-debian: .setup-debian
+
+.setup-debian:
+	sudo apt install -y libmysqlclient-dev build-essential python3.12-dev
+	pyenv install -s 3.12
+	$(call run_in_all_subdirs,setup-debian)
+	touch .setup-debian
+
+setup-arch: .setup-arch
+
+.setup-arch:
+	touch .setup-arch
 
 #-#
 #-# docker-image:

--- a/config.sh
+++ b/config.sh
@@ -156,7 +156,21 @@ if [ ! -r .env.localdb ] ; then
     echo ACCOUNT_PORTAL_APP_PORT=21514 >>  .env.localdb
     echo ACCOUNT_PORTAL_APP_TAG=gcr.io/arxiv-development/arxiv-keycloak/account-portal  >>  .env.localdb
     echo ACCOUNT_PORTAL_APP_NAME=account-portal >> .env.localdb
+
     #
+    # Do OS detection so that we can have automatic setup / install on Debian (at least)
+    #
+    OS=${OS:-unknown}
+    if [[ $OSTYPE == 'linux'* ]] ; then
+        if [ -r /etc/debian_version ] ; then
+            OS=debian
+        elif [ -r /etc/arch-release ] ; then
+            OS=arch
+        fi
+    elif [[ $OSTYPE == 'darwin'* ]] ; then
+        OS=macos
+    fi
+    echo OS=$OS >> .env.localdb
 
 fi
 

--- a/keycloak_bend/Makefile
+++ b/keycloak_bend/Makefile
@@ -18,17 +18,28 @@ all: .env.localdb
 #-#   bootstraps the environment
 bootstrap: .bootstrap
 
-.bootstrap: ./cert/dev-authdb-client-cert.pem ./keycloak-cert/keycloak-self-signed.jks
+.bootstrap: ./cert/dev-authdb-client-cert.pem ./keycloak-cert/keycloak-self-signed.jks setup-$(OS)
+	touch .bootstrap
+
+setup-debian: .setup-debian
+
+.setup-debian:
 	pyenv install -s 3.12
 	if ! dpkg -l | grep -q docker-compose-plugin; then sudo apt install -y docker-compose-plugin; fi
 	${MAKE} venv/bin/poetry
-	touch .bootstrap
+	touch .setup-debian
+
+setup-arch: .setup-arch
+
+.setup-arch:
+	touch .setup-arch
 
 ./cert/dev-authdb-client-cert.pem:
 	cd ./cert/ && ${MAKE} 
 
 ./keycloak-cert/keycloak-self-signed.jks:
-	cd ./keycloak-cert/ && ${MAKE} 
+	echo "THIS DIRECTORY IS MISSING: keycloak-cert/"
+	# cd ./keycloak-cert/ && ${MAKE} 
 
 
 venv:
@@ -82,7 +93,7 @@ pubsub-listener/keycloak-to-pubsub-jar-with-dependencies.jar:
 #-# proxy:
 #-#  Starts proxy connection to dev auth db using port 3030
 proxy:
-	/usr/local/bin/cloud-sql-proxy --address 0.0.0.0 --port 3030 arxiv-development:us-central1:authdb > /dev/null 2>&1 &
+	cloud-sql-proxy --address 0.0.0.0 --port 3030 arxiv-development:us-central1:authdb > /dev/null 2>&1 &
 
 #-#
 #-# sql:

--- a/keycloak_bend/keycloak_migration/Makefile
+++ b/keycloak_bend/keycloak_migration/Makefile
@@ -5,8 +5,12 @@ all: keycloak-user-migration/target/keycloak-rest-provider-5.0.1-SNAPSHOT.jar
 keycloak-user-migration:
 	git clone https://github.com/daniel-frak/keycloak-user-migration.git
 
-keycloak-user-migration/target/keycloak-rest-provider-5.0.1-SNAPSHOT.jar: keycloak-user-migration /usr/bin/java /usr/bin/mvn
+keycloak-user-migration/target/keycloak-rest-provider-5.0.1-SNAPSHOT.jar: keycloak-user-migration setup-$(OS)
 	cd keycloak-user-migration && mvn clean install
+
+setup-debian: /usr/bin/java /usr/bin/mvn
+
+setup-arch:
 
 /usr/bin/java:
 	sudo apt install -y openjdk-21-jdk

--- a/keycloak_tapir_bridge/Makefile
+++ b/keycloak_tapir_bridge/Makefile
@@ -7,8 +7,18 @@ tag := ${KC_TAPIR_BRIDGE_DOCKER_TAG}
 
 bootstrap: .bootstrap
 
-.bootstrap: venv/lib/python3.12/site-packages/google
+.bootstrap: setup-$(OS)
 	touch $@
+
+setup-debian: .setup-debian
+
+.setup-debian: venv/lib/python3.12/site-packages/google
+	touch .setup-debian
+
+setup-arch: .setup-arch
+
+.setup-arch:
+	touch .setup-arch
 
 venv:
 	python3.12 -m venv venv

--- a/legacy_auth_provider/Makefile
+++ b/legacy_auth_provider/Makefile
@@ -39,8 +39,12 @@ venv/lib/python3.12/site-packages/fastapi: venv/bin/poetry
 
 venv/bin/pytest: venv/lib/python3.12/site-packages/fastapi
 
-bootstrap: venv/lib/python3.12/site-packages/fastapi
+bootstrap: setup-$(OS)
 	@echo "nothing to be done"
+
+setup-debian: venv/lib/python3.12/site-packages/fastapi
+
+setup-arch:
 
 docker-image:
 	docker build --progress=plain --platform=linux/amd64 -t ${tag}:latest .

--- a/oauth2-authenticator/Makefile
+++ b/oauth2-authenticator/Makefile
@@ -44,7 +44,11 @@ HELLO:
 	@echo Docker command params is:
 	@echo ${APP_DOCKER_RUN}
 
-bootstrap: venv/lib/python3.12/site-packages/fastapi
+bootstrap: setup-$(OS)
+
+setup-debian: venv/lib/python3.12/site-packages/fastapi
+
+setup-arch:
 
 #-#
 #-# Command: help

--- a/test-mta/Makefile
+++ b/test-mta/Makefile
@@ -20,10 +20,14 @@ help:
 #-#
 #-# bootstrap:
 #-#   sets up the tools.
-boostrap: .bootstrap
+bootstrap: .bootstrap
 
-.bootstrap: venv/lib/python3.12/site-packages/fastapi
+.bootstrap: setup-$(OS)
 	touch .bootstrap
+
+setup-debian: venv/lib/python3.12/site-packages/fastapi
+
+setup-arch:
 
 venv:
 	python3.12 -m venv venv

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -20,8 +20,20 @@ help:
 #-# bootstrap:
 #-#   sets up the tools.
 bootstrap: .bootstrap
-	bash ./install_firefox_esr.sh
+
+.bootstrap: setup-$(OS)
 	touch .bootstrap
+
+setup-debian: .setup-debian
+
+.setup-debian: venv/bin/poetry
+	bash ./install_firefox_esr.sh
+	touch .setup-debian
+
+setup-arch: .setup-arch
+
+.setup-arch:
+	touch .setup-arch
 
 venv:
 	python3.12 -m venv venv
@@ -29,9 +41,6 @@ venv:
 venv/bin/poetry: venv
 	. venv/bin/activate && pip install poetry
 	. venv/bin/activate && poetry install
-
-.bootstrap: venv/bin/poetry
-	touch .bootstrap
 
 #-#
 #-# load-arxiv-test-db-schema:

--- a/user-portal/Makefile
+++ b/user-portal/Makefile
@@ -39,7 +39,11 @@ HELLO:
 	@echo Docker command params is:
 	@echo ${APP_DOCKER_RUN}
 
-bootstrap: venv/lib/python3.12/site-packages/fastapi
+bootstrap: setup-$(OS)
+
+setup-debian: venv/lib/python3.12/site-packages/fastapi
+
+setup-arch: 
 
 #-#
 #-# Command: help


### PR DESCRIPTION
- (config.sh) try to auto-detect the OS and put a variable OS=debian|arch|macos|unknown into the .env file
- make sure that we don't call apt or pip or pyenv commands in the Makefiles when OS=arch
- update .gitignore